### PR TITLE
feat: refactor benchmarks to use nested b.Run() with per-input granularity

### DIFF
--- a/benchmarks/curated/Email_test.go
+++ b/benchmarks/curated/Email_test.go
@@ -1,6 +1,7 @@
 package curated
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 )
@@ -33,20 +34,27 @@ func TestEmailMatchBytes(t *testing.T) {
 	}
 }
 
-func BenchmarkEmailMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range emailTestInputs {
-			_ = Email{}.MatchString(input)
-		}
-	}
-}
+func BenchmarkEmail(b *testing.B) {
+	inputs := emailTestInputs
 
-func BenchmarkStdlibEmailMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range emailTestInputs {
-			_ = emailRegexp.MatchString(input)
+	b.Run("Match", func(b *testing.B) {
+		for i, input := range inputs {
+			input := input
+			b.Run(fmt.Sprintf("Input[%d]", i), func(b *testing.B) {
+				b.Run("stdlib", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = emailRegexp.MatchString(input)
+					}
+				})
+				b.Run("regengo", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = Email{}.MatchString(input)
+					}
+				})
+			})
 		}
-	}
+	})
+
 }

--- a/benchmarks/curated/Greedy_test.go
+++ b/benchmarks/curated/Greedy_test.go
@@ -1,6 +1,7 @@
 package curated
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 )
@@ -33,20 +34,27 @@ func TestGreedyMatchBytes(t *testing.T) {
 	}
 }
 
-func BenchmarkGreedyMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range greedyTestInputs {
-			_ = Greedy{}.MatchString(input)
-		}
-	}
-}
+func BenchmarkGreedy(b *testing.B) {
+	inputs := greedyTestInputs
 
-func BenchmarkStdlibGreedyMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range greedyTestInputs {
-			_ = greedyRegexp.MatchString(input)
+	b.Run("Match", func(b *testing.B) {
+		for i, input := range inputs {
+			input := input
+			b.Run(fmt.Sprintf("Input[%d]", i), func(b *testing.B) {
+				b.Run("stdlib", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = greedyRegexp.MatchString(input)
+					}
+				})
+				b.Run("regengo", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = Greedy{}.MatchString(input)
+					}
+				})
+			})
 		}
-	}
+	})
+
 }

--- a/benchmarks/curated/Lazy_test.go
+++ b/benchmarks/curated/Lazy_test.go
@@ -1,6 +1,7 @@
 package curated
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 )
@@ -33,20 +34,27 @@ func TestLazyMatchBytes(t *testing.T) {
 	}
 }
 
-func BenchmarkLazyMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range lazyTestInputs {
-			_ = Lazy{}.MatchString(input)
-		}
-	}
-}
+func BenchmarkLazy(b *testing.B) {
+	inputs := lazyTestInputs
 
-func BenchmarkStdlibLazyMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range lazyTestInputs {
-			_ = lazyRegexp.MatchString(input)
+	b.Run("Match", func(b *testing.B) {
+		for i, input := range inputs {
+			input := input
+			b.Run(fmt.Sprintf("Input[%d]", i), func(b *testing.B) {
+				b.Run("stdlib", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = lazyRegexp.MatchString(input)
+					}
+				})
+				b.Run("regengo", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = Lazy{}.MatchString(input)
+					}
+				})
+			})
 		}
-	}
+	})
+
 }

--- a/benchmarks/curated/TDFAComplexURL_test.go
+++ b/benchmarks/curated/TDFAComplexURL_test.go
@@ -1,6 +1,7 @@
 package curated
 
 import (
+	"fmt"
 	stream "github.com/KromDaniel/regengo/stream"
 	"regexp"
 	"strings"
@@ -125,78 +126,83 @@ func TestTDFAComplexURLFindAllString(t *testing.T) {
 	}
 }
 
-func BenchmarkTDFAComplexURLMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFAComplexURLTestInputs {
-			_ = TDFAComplexURL{}.MatchString(input)
-		}
-	}
-}
+func BenchmarkTDFAComplexURL(b *testing.B) {
+	inputs := tDFAComplexURLTestInputs
 
-func BenchmarkStdlibTDFAComplexURLMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFAComplexURLTestInputs {
-			_ = tDFAComplexURLRegexp.MatchString(input)
+	b.Run("Match", func(b *testing.B) {
+		for i, input := range inputs {
+			input := input
+			b.Run(fmt.Sprintf("Input[%d]", i), func(b *testing.B) {
+				b.Run("stdlib", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = tDFAComplexURLRegexp.MatchString(input)
+					}
+				})
+				b.Run("regengo", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = TDFAComplexURL{}.MatchString(input)
+					}
+				})
+			})
 		}
-	}
-}
+	})
 
-func BenchmarkTDFAComplexURLFindString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFAComplexURLTestInputs {
-			_, _ = TDFAComplexURL{}.FindString(input)
+	b.Run("FindFirst", func(b *testing.B) {
+		for i, input := range inputs {
+			input := input
+			b.Run(fmt.Sprintf("Input[%d]", i), func(b *testing.B) {
+				b.Run("stdlib", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = tDFAComplexURLRegexp.FindStringSubmatch(input)
+					}
+				})
+				b.Run("regengo", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_, _ = TDFAComplexURL{}.FindString(input)
+					}
+				})
+				b.Run("regengo_reuse", func(b *testing.B) {
+					b.ReportAllocs()
+					var result *TDFAComplexURLResult
+					for b.Loop() {
+						result, _ = TDFAComplexURL{}.FindStringReuse(input, result)
+					}
+				})
+			})
 		}
-	}
-}
+	})
 
-func BenchmarkStdlibTDFAComplexURLFindStringSubmatch(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFAComplexURLTestInputs {
-			_ = tDFAComplexURLRegexp.FindStringSubmatch(input)
+	b.Run("FindAll", func(b *testing.B) {
+		for i, input := range inputs {
+			input := input
+			b.Run(fmt.Sprintf("Input[%d]", i), func(b *testing.B) {
+				b.Run("stdlib", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = tDFAComplexURLRegexp.FindAllStringSubmatch(input, -1)
+					}
+				})
+				b.Run("regengo", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = TDFAComplexURL{}.FindAllString(input, -1)
+					}
+				})
+				b.Run("regengo_append", func(b *testing.B) {
+					b.ReportAllocs()
+					results := make([]*TDFAComplexURLResult, 0, 100)
+					for b.Loop() {
+						results = TDFAComplexURL{}.FindAllStringAppend(input, -1, results[:0])
+					}
+				})
+			})
 		}
-	}
-}
+	})
 
-func BenchmarkTDFAComplexURLFindStringReuse(b *testing.B) {
-	b.ReportAllocs()
-	var result *TDFAComplexURLResult
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFAComplexURLTestInputs {
-			result, _ = TDFAComplexURL{}.FindStringReuse(input, result)
-		}
-	}
-}
-
-func BenchmarkTDFAComplexURLFindAllString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFAComplexURLTestInputs {
-			_ = TDFAComplexURL{}.FindAllString(input, -1)
-		}
-	}
-}
-
-func BenchmarkTDFAComplexURLFindAllStringAppend(b *testing.B) {
-	b.ReportAllocs()
-	results := make([]*TDFAComplexURLResult, 0, 100)
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFAComplexURLTestInputs {
-			results = TDFAComplexURL{}.FindAllStringAppend(input, -1, results[:0])
-		}
-	}
-}
-
-func BenchmarkStdlibTDFAComplexURLFindAllStringSubmatch(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFAComplexURLTestInputs {
-			_ = tDFAComplexURLRegexp.FindAllStringSubmatch(input, -1)
-		}
-	}
 }
 
 func TestTDFAComplexURLFindReader(t *testing.T) {

--- a/benchmarks/curated/TDFANestedWord_test.go
+++ b/benchmarks/curated/TDFANestedWord_test.go
@@ -1,6 +1,7 @@
 package curated
 
 import (
+	"fmt"
 	stream "github.com/KromDaniel/regengo/stream"
 	"regexp"
 	"strings"
@@ -89,78 +90,83 @@ func TestTDFANestedWordFindAllString(t *testing.T) {
 	}
 }
 
-func BenchmarkTDFANestedWordMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFANestedWordTestInputs {
-			_ = TDFANestedWord{}.MatchString(input)
-		}
-	}
-}
+func BenchmarkTDFANestedWord(b *testing.B) {
+	inputs := tDFANestedWordTestInputs
 
-func BenchmarkStdlibTDFANestedWordMatchString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFANestedWordTestInputs {
-			_ = tDFANestedWordRegexp.MatchString(input)
+	b.Run("Match", func(b *testing.B) {
+		for i, input := range inputs {
+			input := input
+			b.Run(fmt.Sprintf("Input[%d]", i), func(b *testing.B) {
+				b.Run("stdlib", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = tDFANestedWordRegexp.MatchString(input)
+					}
+				})
+				b.Run("regengo", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = TDFANestedWord{}.MatchString(input)
+					}
+				})
+			})
 		}
-	}
-}
+	})
 
-func BenchmarkTDFANestedWordFindString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFANestedWordTestInputs {
-			_, _ = TDFANestedWord{}.FindString(input)
+	b.Run("FindFirst", func(b *testing.B) {
+		for i, input := range inputs {
+			input := input
+			b.Run(fmt.Sprintf("Input[%d]", i), func(b *testing.B) {
+				b.Run("stdlib", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = tDFANestedWordRegexp.FindStringSubmatch(input)
+					}
+				})
+				b.Run("regengo", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_, _ = TDFANestedWord{}.FindString(input)
+					}
+				})
+				b.Run("regengo_reuse", func(b *testing.B) {
+					b.ReportAllocs()
+					var result *TDFANestedWordResult
+					for b.Loop() {
+						result, _ = TDFANestedWord{}.FindStringReuse(input, result)
+					}
+				})
+			})
 		}
-	}
-}
+	})
 
-func BenchmarkStdlibTDFANestedWordFindStringSubmatch(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFANestedWordTestInputs {
-			_ = tDFANestedWordRegexp.FindStringSubmatch(input)
+	b.Run("FindAll", func(b *testing.B) {
+		for i, input := range inputs {
+			input := input
+			b.Run(fmt.Sprintf("Input[%d]", i), func(b *testing.B) {
+				b.Run("stdlib", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = tDFANestedWordRegexp.FindAllStringSubmatch(input, -1)
+					}
+				})
+				b.Run("regengo", func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = TDFANestedWord{}.FindAllString(input, -1)
+					}
+				})
+				b.Run("regengo_append", func(b *testing.B) {
+					b.ReportAllocs()
+					results := make([]*TDFANestedWordResult, 0, 100)
+					for b.Loop() {
+						results = TDFANestedWord{}.FindAllStringAppend(input, -1, results[:0])
+					}
+				})
+			})
 		}
-	}
-}
+	})
 
-func BenchmarkTDFANestedWordFindStringReuse(b *testing.B) {
-	b.ReportAllocs()
-	var result *TDFANestedWordResult
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFANestedWordTestInputs {
-			result, _ = TDFANestedWord{}.FindStringReuse(input, result)
-		}
-	}
-}
-
-func BenchmarkTDFANestedWordFindAllString(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFANestedWordTestInputs {
-			_ = TDFANestedWord{}.FindAllString(input, -1)
-		}
-	}
-}
-
-func BenchmarkTDFANestedWordFindAllStringAppend(b *testing.B) {
-	b.ReportAllocs()
-	results := make([]*TDFANestedWordResult, 0, 100)
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFANestedWordTestInputs {
-			results = TDFANestedWord{}.FindAllStringAppend(input, -1, results[:0])
-		}
-	}
-}
-
-func BenchmarkStdlibTDFANestedWordFindAllStringSubmatch(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, input := range tDFANestedWordTestInputs {
-			_ = tDFANestedWordRegexp.FindAllStringSubmatch(input, -1)
-		}
-	}
 }
 
 func TestTDFANestedWordFindReader(t *testing.T) {

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -618,7 +618,50 @@ URL redaction with selective capture group output
 
 ## Running Benchmarks
 
-To run benchmarks yourself:
+### Benchmark Structure
+
+Benchmarks use a nested structure for clear comparison:
+
+```
+Benchmark{Pattern}/
+├── Match/Input[i]/{stdlib,regengo}
+├── FindFirst/Input[i]/{stdlib,regengo,regengo_reuse}
+├── FindAll/Input[i]/{stdlib,regengo,regengo_append}
+└── Replace/Template[j]/Input[i]/{stdlib,regengo_runtime,regengo,regengo_append}
+```
+
+### Running Specific Benchmarks
+
+```bash
+# Run all benchmarks for a pattern
+go test ./benchmarks/curated/... -bench="BenchmarkDateCapture" -benchmem
+
+# Run only Match benchmarks
+go test ./benchmarks/curated/... -bench="Match" -benchmem
+
+# Run only regengo_reuse variants
+go test ./benchmarks/curated/... -bench="regengo_reuse" -benchmem
+
+# Run specific input
+go test ./benchmarks/curated/... -bench="Input\[0\]" -benchmem
+```
+
+### Aggregating Results
+
+Use the aggregation script for summary statistics across all inputs:
+
+```bash
+# Aggregate results for a pattern
+go test ./benchmarks/curated/... -bench="BenchmarkDateCapture" -benchmem | go run scripts/curated/aggregate.go
+
+# Example output:
+# Pattern: DateCapture
+#   Category: Match
+#     stdlib:            avg=   73.86 ns  min=   73.15  max=   74.28  allocs=0
+#     regengo:           avg=    3.91 ns  min=    3.86  max=    4.01  allocs=0  (18.9x faster)
+```
+
+### Make Targets
 
 ```bash
 # Run benchmarks (generates and runs curated benchmarks)
@@ -636,8 +679,12 @@ make bench-chart
 
 ## Regenerating Results
 
-To regenerate these benchmark tables:
+To regenerate benchmark files after code changes:
 
 ```bash
+# Regenerate curated benchmark code
+go run scripts/curated/generate.go scripts/curated/cases.go
+
+# Or use make
 make bench-format
 ```

--- a/scripts/curated/aggregate.go
+++ b/scripts/curated/aggregate.go
@@ -1,0 +1,291 @@
+// aggregate.go aggregates benchmark results across inputs for summary comparison.
+//
+// Usage:
+//
+//	go test ./benchmarks/curated/... -bench="." -benchmem | go run scripts/curated/aggregate.go
+//	go test ./benchmarks/curated/... -bench="DateCapture" -benchmem | go run scripts/curated/aggregate.go
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// BenchmarkResult holds parsed benchmark data
+type BenchmarkResult struct {
+	Pattern    string
+	Category   string
+	Input      string
+	Variant    string
+	Template   string // for Replace category
+	NsPerOp    float64
+	BytesOp    int64
+	AllocsOp   int64
+	Iterations int64
+}
+
+// AggregatedResult holds aggregated statistics
+type AggregatedResult struct {
+	Variant   string
+	Count     int
+	MinNs     float64
+	MaxNs     float64
+	AvgNs     float64
+	MedianNs  float64
+	AvgBytes  int64
+	AvgAllocs int64
+	AllNs     []float64
+}
+
+// benchmarkLineRe matches benchmark output lines
+// Example: BenchmarkDateCapture/Match/Input[0]/stdlib-12  	16418577	        72.75 ns/op	       0 B/op	       0 allocs/op
+var benchmarkLineRe = regexp.MustCompile(
+	`^(Benchmark\S+)-\d+\s+(\d+)\s+([\d.]+)\s+ns/op(?:\s+(\d+)\s+B/op)?(?:\s+(\d+)\s+allocs/op)?`,
+)
+
+func main() {
+	results := parseBenchmarks(os.Stdin)
+	if len(results) == 0 {
+		fmt.Println("No benchmark results found.")
+		return
+	}
+
+	// Group by pattern -> category -> (template ->) variant
+	grouped := groupResults(results)
+
+	// Print aggregated results
+	printAggregated(grouped)
+}
+
+func parseBenchmarks(f *os.File) []BenchmarkResult {
+	var results []BenchmarkResult
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		match := benchmarkLineRe.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+
+		name := match[1]
+		iterations, _ := strconv.ParseInt(match[2], 10, 64)
+		nsPerOp, _ := strconv.ParseFloat(match[3], 64)
+		var bytesOp, allocsOp int64
+		if match[4] != "" {
+			bytesOp, _ = strconv.ParseInt(match[4], 10, 64)
+		}
+		if match[5] != "" {
+			allocsOp, _ = strconv.ParseInt(match[5], 10, 64)
+		}
+
+		result := parseBenchmarkName(name)
+		if result == nil {
+			continue
+		}
+
+		result.NsPerOp = nsPerOp
+		result.BytesOp = bytesOp
+		result.AllocsOp = allocsOp
+		result.Iterations = iterations
+
+		results = append(results, *result)
+	}
+
+	return results
+}
+
+// parseBenchmarkName extracts components from benchmark name
+// Examples:
+//   - BenchmarkDateCapture/Match/Input[0]/stdlib
+//   - BenchmarkReplaceDate/Replace/Template[0]/Input[0]/regengo_append
+func parseBenchmarkName(name string) *BenchmarkResult {
+	// Remove "Benchmark" prefix
+	if !strings.HasPrefix(name, "Benchmark") {
+		return nil
+	}
+	name = strings.TrimPrefix(name, "Benchmark")
+
+	parts := strings.Split(name, "/")
+	if len(parts) < 3 {
+		return nil
+	}
+
+	result := &BenchmarkResult{
+		Pattern: parts[0],
+	}
+
+	// Handle different structures
+	// Match/FindFirst/FindAll: Pattern/Category/Input[i]/variant
+	// Replace: Pattern/Category/Template[j]/Input[i]/variant
+	if parts[1] == "Replace" && len(parts) >= 5 {
+		result.Category = parts[1]
+		result.Template = parts[2]
+		result.Input = parts[3]
+		result.Variant = parts[4]
+	} else if len(parts) >= 4 {
+		result.Category = parts[1]
+		result.Input = parts[2]
+		result.Variant = parts[3]
+	} else {
+		return nil
+	}
+
+	return result
+}
+
+// groupResults groups results by pattern -> category -> (template ->) variant
+func groupResults(results []BenchmarkResult) map[string]map[string]map[string][]BenchmarkResult {
+	grouped := make(map[string]map[string]map[string][]BenchmarkResult)
+
+	for _, r := range results {
+		if grouped[r.Pattern] == nil {
+			grouped[r.Pattern] = make(map[string]map[string][]BenchmarkResult)
+		}
+
+		categoryKey := r.Category
+		if r.Template != "" {
+			categoryKey = r.Category + "/" + r.Template
+		}
+
+		if grouped[r.Pattern][categoryKey] == nil {
+			grouped[r.Pattern][categoryKey] = make(map[string][]BenchmarkResult)
+		}
+
+		grouped[r.Pattern][categoryKey][r.Variant] = append(
+			grouped[r.Pattern][categoryKey][r.Variant], r,
+		)
+	}
+
+	return grouped
+}
+
+func aggregateVariant(results []BenchmarkResult) AggregatedResult {
+	if len(results) == 0 {
+		return AggregatedResult{}
+	}
+
+	var allNs []float64
+	var totalBytes, totalAllocs int64
+
+	for _, r := range results {
+		allNs = append(allNs, r.NsPerOp)
+		totalBytes += r.BytesOp
+		totalAllocs += r.AllocsOp
+	}
+
+	sort.Float64s(allNs)
+
+	var sum float64
+	for _, ns := range allNs {
+		sum += ns
+	}
+
+	median := allNs[len(allNs)/2]
+	if len(allNs)%2 == 0 && len(allNs) > 1 {
+		median = (allNs[len(allNs)/2-1] + allNs[len(allNs)/2]) / 2
+	}
+
+	return AggregatedResult{
+		Variant:   results[0].Variant,
+		Count:     len(results),
+		MinNs:     allNs[0],
+		MaxNs:     allNs[len(allNs)-1],
+		AvgNs:     sum / float64(len(allNs)),
+		MedianNs:  median,
+		AvgBytes:  totalBytes / int64(len(results)),
+		AvgAllocs: totalAllocs / int64(len(results)),
+		AllNs:     allNs,
+	}
+}
+
+func printAggregated(grouped map[string]map[string]map[string][]BenchmarkResult) {
+	// Sort patterns for consistent output
+	var patterns []string
+	for p := range grouped {
+		patterns = append(patterns, p)
+	}
+	sort.Strings(patterns)
+
+	for _, pattern := range patterns {
+		fmt.Printf("\n%s\n", strings.Repeat("=", 60))
+		fmt.Printf("Pattern: %s\n", pattern)
+		fmt.Printf("%s\n", strings.Repeat("=", 60))
+
+		categories := grouped[pattern]
+
+		// Sort categories
+		var categoryKeys []string
+		for c := range categories {
+			categoryKeys = append(categoryKeys, c)
+		}
+		sort.Strings(categoryKeys)
+
+		for _, categoryKey := range categoryKeys {
+			variants := categories[categoryKey]
+
+			fmt.Printf("\n  Category: %s\n", categoryKey)
+			fmt.Printf("  %s\n", strings.Repeat("-", 50))
+
+			// Aggregate each variant
+			var aggregated []AggregatedResult
+			for variant, results := range variants {
+				agg := aggregateVariant(results)
+				agg.Variant = variant
+				aggregated = append(aggregated, agg)
+			}
+
+			// Sort variants: stdlib first, then regengo variants
+			sort.Slice(aggregated, func(i, j int) bool {
+				order := map[string]int{
+					"stdlib":          0,
+					"regengo":         1,
+					"regengo_runtime": 2,
+					"regengo_reuse":   3,
+					"regengo_append":  4,
+				}
+				oi, ok1 := order[aggregated[i].Variant]
+				oj, ok2 := order[aggregated[j].Variant]
+				if !ok1 {
+					oi = 100
+				}
+				if !ok2 {
+					oj = 100
+				}
+				return oi < oj
+			})
+
+			// Find stdlib for speedup calculation
+			var stdlibAvg float64
+			for _, agg := range aggregated {
+				if agg.Variant == "stdlib" {
+					stdlibAvg = agg.AvgNs
+					break
+				}
+			}
+
+			// Print results
+			for _, agg := range aggregated {
+				speedup := ""
+				if stdlibAvg > 0 && agg.Variant != "stdlib" {
+					speedup = fmt.Sprintf("  (%.1fx faster)", stdlibAvg/agg.AvgNs)
+				}
+
+				fmt.Printf("    %-18s avg=%8.2f ns  min=%8.2f  max=%8.2f  allocs=%d%s\n",
+					agg.Variant+":",
+					agg.AvgNs,
+					agg.MinNs,
+					agg.MaxNs,
+					agg.AvgAllocs,
+					speedup,
+				)
+			}
+		}
+	}
+	fmt.Println()
+}


### PR DESCRIPTION
## Summary

- Refactored benchmark generation to use nested `b.Run()` calls with structure: `BenchmarkPattern/Category/Input[i]/variant`
- Replaced `for i := 0; i < b.N; i++` with Go 1.24+ `for b.Loop()` syntax
- Created new `scripts/curated/aggregate.go` for aggregating results across inputs
- Updated all scripts (`analyze.go`, `format.go`, `chart.py`) to parse the new nested format

## Test plan

- [x] All 17 curated patterns regenerate without errors
- [x] All generated files compile: `go build ./benchmarks/curated/...`
- [x] All unit tests pass: `go test ./benchmarks/curated/...`
- [x] Benchmark output shows nested structure
- [x] All scripts parse new format correctly
- [x] Pre-commit hooks pass
